### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/site/js/dns-service.js
+++ b/src/site/js/dns-service.js
@@ -437,16 +437,41 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!hasResults && normalizedFilter) {
             const noResults = document.createElement('div');
             noResults.className = 'no-results';
-            noResults.innerHTML = `
-                <p>No services found matching "<strong>${filterText}</strong>". <br>They might not be blocked, or are listed under a different name.</p>
-                <a href="https://github.com/hapara-fail/blocklist/issues/new?template=additions-removals.md" target="_blank" rel="noopener noreferrer" class="cta-button" style="margin-top: 15px; display: inline-flex; font-size: 0.9rem; align-items: center; gap: 8px;">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                        <line x1="12" y1="5" x2="12" y2="19"></line>
-                        <line x1="5" y1="12" x2="19" y2="12"></line>
-                    </svg>
-                    Request to add this service
-                </a>
+
+            const messagePara = document.createElement('p');
+            messagePara.appendChild(document.createTextNode('No services found matching "'));
+
+            const strongEl = document.createElement('strong');
+            strongEl.textContent = filterText;
+            messagePara.appendChild(strongEl);
+
+            messagePara.appendChild(document.createTextNode('". '));
+            const br = document.createElement('br');
+            messagePara.appendChild(br);
+            messagePara.appendChild(document.createTextNode('They might not be blocked, or are listed under a different name.'));
+
+            noResults.appendChild(messagePara);
+
+            const link = document.createElement('a');
+            link.href = 'https://github.com/hapara-fail/blocklist/issues/new?template=additions-removals.md';
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            link.className = 'cta-button';
+            link.style.marginTop = '15px';
+            link.style.display = 'inline-flex';
+            link.style.fontSize = '0.9rem';
+            link.style.alignItems = 'center';
+            link.style.gap = '8px';
+
+            link.innerHTML = `
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="12" y1="5" x2="12" y2="19"></line>
+                    <line x1="5" y1="12" x2="19" y2="12"></line>
+                </svg>
+                Request to add this service
             `;
+
+            noResults.appendChild(link);
             serviceList.appendChild(noResults);
         }
     };


### PR DESCRIPTION
Potential fix for [https://github.com/hapara-fail/website/security/code-scanning/2](https://github.com/hapara-fail/website/security/code-scanning/2)

In general, the problem should be fixed by ensuring any user-controlled data is HTML-escaped (or inserted via text properties like `textContent`) before being added to the DOM. Avoid interpolating raw user input inside strings assigned to `innerHTML`.

The best minimal fix here is to stop using `innerHTML` to embed `filterText` and instead construct the `noResults` DOM subtree manually. We can still use `innerHTML` for the static, non-user-controlled SVG and link markup, but the user-controlled `filterText` should go into a `textNode` or an element’s `textContent`. Concretely, in `renderServices` (around lines 437–451), replace the block where `noResults.innerHTML` is set with code that:
- Creates a `<p>` element.
- Sets its `innerHTML` only for the static parts around the search term or, more robustly, builds it via DOM nodes.
- Inserts the `filterText` into a newly created `<strong>` element using `textContent`.
- Appends the `<strong>` into the `<p>` at the appropriate point.
- Still appends the static `<a>` CTA link similarly but without any user data.

This change only affects `src/site/js/dns-service.js` in the `renderServices` function and does not alter the visible behavior, except that any HTML meta-characters in the search text will now be displayed literally rather than interpreted as markup, which is the intended safe behavior. No additional imports or external libraries are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
