### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/site/js/index.js
+++ b/src/site/js/index.js
@@ -32,12 +32,21 @@ document.addEventListener('DOMContentLoaded', () => {
         const heroTitle = document.querySelector('.hero-title');
         if (heroTitle) {
             const text = heroTitle.textContent.trim();
-            // Build word wrappers
-            heroTitle.innerHTML = text.split(' ').map(word => `<span class="word-wrapper"><span class="word">${word}</span></span>`).join(' ');
-            
-            const words = heroTitle.querySelectorAll('.word');
-            words.forEach((word, i) => {
-                word.style.transitionDelay = `${i * 100}ms`;
+            // Build word wrappers safely using DOM APIs
+            const wordsArray = text.split(/\s+/);
+            heroTitle.textContent = '';
+            wordsArray.forEach((word, index) => {
+                const wrapper = document.createElement('span');
+                wrapper.className = 'word-wrapper';
+                const wordSpan = document.createElement('span');
+                wordSpan.className = 'word';
+                wordSpan.textContent = word;
+                wordSpan.style.transitionDelay = `${index * 100}ms`;
+                wrapper.appendChild(wordSpan);
+                heroTitle.appendChild(wrapper);
+                if (index < wordsArray.length - 1) {
+                    heroTitle.appendChild(document.createTextNode(' '));
+                }
             });
 
             // Force layout then add class to trigger animation


### PR DESCRIPTION
Potential fix for [https://github.com/hapara-fail/website/security/code-scanning/1](https://github.com/hapara-fail/website/security/code-scanning/1)

In general, to fix this kind of issue you must avoid feeding unescaped DOM text into `innerHTML` or any other HTML-parsing sink. Either: (1) escape the text so that any `<`/`>`/`&`/`"`/`'` characters are encoded and treated as literal text, or (2) do not use HTML strings at all and instead create and append elements with `document.createElement` and `textContent`, which preserves the animation behavior without reinterpreting arbitrary text as markup.

Here, the best fix without changing visible functionality is to drop the `innerHTML`-based reconstruction and build the `.word-wrapper` and `.word` spans using DOM APIs. We still read `heroTitle.textContent.trim()`, split it into words, clear the element, then for each word create a `span.word-wrapper` containing a `span.word` whose `textContent` is set to the word. This keeps the same DOM structure that the CSS animation expects while ensuring each word is safely inserted as text, not HTML. Only the hero-title block (lines 32–47) needs updating in `src/site/js/index.js`, and no new imports or external libraries are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
